### PR TITLE
Update to latest Rust nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ name = "jqsh"
 path = "src/lib.rs"
 
 [dependencies]
+chan = "*"
+eventual = "*"
 itertools = "*"
 num = "*"
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1,6 +1,9 @@
+extern crate eventual;
 extern crate jqsh;
 extern crate readline;
 extern crate unicode;
+
+use eventual::Async;
 
 use unicode::UString;
 
@@ -15,9 +18,9 @@ fn main() {
             println!("jqsh: syntax error: {:?}", err);
             Filter::Empty
         });
-        let mut output = channel::Receiver::empty(repl_context).filter(&filter);
-        repl_context = output.context();
-        for value in output {
+        let channel::Receiver { context, values } = channel::Receiver::empty(repl_context).filter(&filter);
+        repl_context = context.await().expect("failed to get repl output context");
+        for value in values {
             println!("{}", value);
         }
     }

--- a/src/lang/channel.rs
+++ b/src/lang/channel.rs
@@ -6,11 +6,6 @@ use eventual::{self, Async};
 
 use lang::{Context, Filter, Value};
 
-pub enum ChannelError {
-    /// This part of the channel is already closed. Occurs when calling `close` multiple times or when calling `send` after `close`.
-    Closed
-}
-
 pub struct Sender {
     pub context: eventual::Complete<Context, ()>,
     pub values: chan::Sender<Value>

--- a/src/lang/value/array.rs
+++ b/src/lang/value/array.rs
@@ -1,5 +1,5 @@
 use std::hash;
-use std::iter::{order, FromIterator};
+use std::iter::FromIterator;
 use std::sync::mpsc;
 
 use lang::channel::Receiver;
@@ -42,7 +42,7 @@ impl<T> From<Vec<T>> for Array<T> {
 
 impl From<Receiver> for Array<Value> {
     fn from(rx: Receiver) -> Array<Value> {
-        Array { buffer: rx.collect() } //TODO implement lazy arrays
+        Array { buffer: rx.values.into_iter().collect() } //TODO implement lazy arrays
     }
 }
 
@@ -110,7 +110,7 @@ impl<'a, T> IntoIterator for &'a Array<T> {
 
 impl<T, U> PartialEq<Array<U>> for Array<T> where T: PartialEq<U> {
     fn eq(&self, other: &Array<U>) -> bool {
-        order::eq(self.iter(), other.iter())
+        self.iter().eq(other.iter())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(iter_order)]
 #![cfg_attr(test, deny(missing_docs, warnings))]
 #![forbid(unused_variables)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
-#![feature(core, std_misc)]
+#![feature(iter_order)]
 #![cfg_attr(test, deny(missing_docs, warnings))]
 #![forbid(unused_variables)]
 
+extern crate chan;
+extern crate eventual;
 extern crate itertools;
 extern crate linked_hash_map;
 #[macro_use] extern crate literator;


### PR DESCRIPTION
This now uses the crates [`chan`](https://crates.io/crates/chan) and [`eventual`](https://crates.io/crates/eventual) for channels and futures, respectively, since `std` futures were deprecated and the channels are mpmc.
