### PR TITLE
Add Slack channel info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ With a [prototype](https://github.com/jq-shell/python-jqsh) having been written 
 
 This is version 0.0.1 of jqsh ([semver](http://semver.org/)).
 
-For more info on the project, see [the wiki](https://gitlab.com/jqsh/jqsh/wikis/home).
+For more info on the project, see [the wiki](https://github.com/jq-shell/jqsh/wiki), or join us at [functionalprogramming.slack.com](http://fpchat.com/) #jqsh.


### PR DESCRIPTION
We now have an official channel on the functional programming Slack team, so this updates the readme with a link to their signup form.
