### PR TITLE
Switch to shaleh/readline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ git = "https://github.com/contain-rs/linked-hash-map.git" # crates.io version is
 git = "https://github.com/kmcallister/literator.git"
 
 [dependencies.readline]
-git = "https://github.com/gwenn/rust-readline.git"
+git = "https://github.com/shaleh/rust-readline.git"
 
 [dependencies.unicode]
 git = "https://github.com/fenhl/rust-unicode.git"


### PR DESCRIPTION
@gwenn's [fork](https://github.com/gwenn/rust-readline) no longer compiles, so this changes the dependency back to @shaleh's [upstream](https://github.com/shaleh/rust-readline).
