### PR TITLE
Remove literator dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,6 @@ num = "*"
 [dependencies.linked-hash-map]
 git = "https://github.com/contain-rs/linked-hash-map.git" # crates.io version is outdated
 
-[dependencies.literator]
-git = "https://github.com/kmcallister/literator.git"
-
 [dependencies.readline]
 git = "https://github.com/shaleh/rust-readline.git"
 

--- a/src/lang/context.rs
+++ b/src/lang/context.rs
@@ -24,9 +24,9 @@ impl Context {
     pub fn interactive() -> Context {
         Context {
             filter_allowed: Arc::new(Box::new(|_| true)),
-            operators: literator![
+            operators: vec![
                 (-1000000, PrecedenceGroup::AndThen)
-            ].map(|(precedence, group)| {
+            ].into_iter().map(|(precedence, group)| {
                 (BigRational::from_integer(FromPrimitive::from_i32(precedence).unwrap()), group)
             }).collect()
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ extern crate chan;
 extern crate eventual;
 extern crate itertools;
 extern crate linked_hash_map;
-#[macro_use] extern crate literator;
 extern crate num;
 extern crate unicode;
 


### PR DESCRIPTION
[literator](https://github.com/kmcallister/literator) doesn't compile on beta, so this removes the dependency in preparation for #2.
