### PR TITLE
Remove linked_hash_map dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,6 @@ eventual = "*"
 itertools = "*"
 num = "*"
 
-[dependencies.linked-hash-map]
-git = "https://github.com/contain-rs/linked-hash-map.git" # crates.io version is outdated
-
 [dependencies.readline]
 git = "https://github.com/shaleh/rust-readline.git"
 

--- a/src/lang/value/object.rs
+++ b/src/lang/value/object.rs
@@ -1,26 +1,37 @@
-use std::hash;
-use std::collections::HashMap;
+use std::{hash, mem, vec};
 use std::iter::FromIterator;
-
-use linked_hash_map::{self, LinkedHashMap};
 
 //TODO implement lazy objects by also including a receiver
 #[derive(Clone, Debug)]
-pub struct Object<K: Eq + hash::Hash, V> {
-    buffer: LinkedHashMap<K, V>
+pub struct Object<K: Eq, V> {
+    buffer: Vec<(K, V)>
 }
 
-impl<K: Eq + hash::Hash, V> Object<K, V> {
+impl<K: Eq, V> Object<K, V> {
     pub fn get_idx(&self, idx: usize) -> Option<(&K, &V)> {
-        self.buffer.iter().nth(idx)
+        if self.buffer.len() > idx {
+            let (ref k, ref v) = self.buffer[idx];
+            Some((k, v))
+        } else {
+            None
+        }
     }
 
     pub fn insert(&mut self, k: K, v: V) -> Option<V> {
-        self.buffer.insert(k, v)
+        for &mut (ref key, ref mut val) in &mut self.buffer {
+            if *key == k {
+                return Some(mem::replace(val, v));
+            }
+        }
+        self.buffer.push((k, v));
+        None
     }
 
-    pub fn iter(&self) -> linked_hash_map::Iter<K, V> {
-        self.buffer.iter()
+    pub fn iter(&self) -> Iter<K, V> {
+        Iter {
+            object: self,
+            index: 0
+        }
     }
 
     pub fn len(&self) -> usize {
@@ -28,13 +39,13 @@ impl<K: Eq + hash::Hash, V> Object<K, V> {
     }
 }
 
-impl<K: Eq + hash::Hash, V> Default for Object<K, V> {
+impl<K: Eq, V> Default for Object<K, V> {
     fn default() -> Object<K, V> {
-        Object { buffer: LinkedHashMap::default() }
+        Object { buffer: Vec::default() }
     }
 }
 
-impl<K: Eq + hash::Hash, L: Eq + hash::Hash, V, W> FromIterator<(K, V)> for Object<L, W> where K: Into<L>, V: Into<W> {
+impl<K: Eq, L: Eq, V, W> FromIterator<(K, V)> for Object<L, W> where K: Into<L>, V: Into<W> {
     fn from_iter<I: IntoIterator<Item=(K, V)>>(iter: I) -> Object<L, W> {
         let mut result = Object::default();
         for (k, v) in iter {
@@ -50,45 +61,39 @@ impl<K: Eq + hash::Hash, V: hash::Hash> hash::Hash for Object<K, V> {
     }
 }
 
-impl<K: Eq + hash::Hash, V: PartialEq> PartialEq<Object<K, V>> for Object<K, V> {
+impl<K: Eq, V: PartialEq> PartialEq<Object<K, V>> for Object<K, V> {
     fn eq(&self, other: &Object<K, V>) -> bool {
-        let lhs = self.buffer.iter().collect::<HashMap<&K, &V>>();
-        let rhs = other.buffer.iter().collect::<HashMap<&K, &V>>();
-        lhs == rhs
+        self.buffer.len() == other.buffer.len() &&
+        self.iter().all(|(k1, v1)| other.iter().find(|&(k2, _)| k1 == k2).map_or(false, |(_, v2)| v2 == v1))
     }
 }
 
-impl<K: Eq + hash::Hash, V: Eq> Eq for Object<K, V> {}
+impl<K: Eq, V: Eq> Eq for Object<K, V> {}
 
-impl<K: Eq + hash::Hash + Clone, V> IntoIterator for Object<K, V> {
+impl<K: Eq + Clone, V> IntoIterator for Object<K, V> {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V>;
 
     fn into_iter(self) -> IntoIter<K, V> {
         IntoIter {
-            buffer: self.buffer
+            buffer: self.buffer.into_iter()
         }
     }
 }
 
-pub struct IntoIter<K: Eq + hash::Hash, V> {
-    buffer: LinkedHashMap<K, V>
+pub struct IntoIter<K: Eq, V> {
+    buffer: vec::IntoIter<(K, V)>
 }
 
-impl<K: Eq + hash::Hash + Clone, V> Iterator for IntoIter<K, V> {
+impl<K: Eq, V> Iterator for IntoIter<K, V> {
     type Item = (K, V);
 
     fn next(&mut self) -> Option<(K, V)> {
-        let next_key = match self.buffer.keys().next() {
-            Some(k) => k.clone(),
-            None => { return None; }
-        };
-        let next_value = self.buffer.remove(&next_key).unwrap();
-        Some((next_key, next_value))
+        self.buffer.next()
     }
 }
 
-impl<'a, K: Eq + hash::Hash, V> IntoIterator for &'a Object<K, V> {
+impl<'a, K: Eq, V> IntoIterator for &'a Object<K, V> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;
 
@@ -100,12 +105,12 @@ impl<'a, K: Eq + hash::Hash, V> IntoIterator for &'a Object<K, V> {
     }
 }
 
-pub struct Iter<'a, K: 'a + Eq + hash::Hash, V: 'a> {
+pub struct Iter<'a, K: 'a + Eq, V: 'a> {
     object: &'a Object<K, V>,
     index: usize
 }
 
-impl<'a, K: Eq + hash::Hash, V> Iterator for Iter<'a, K, V> {
+impl<'a, K: Eq, V> Iterator for Iter<'a, K, V> {
     type Item = (&'a K, &'a V);
 
     fn next(&mut self) -> Option<(&'a K, &'a V)> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 extern crate chan;
 extern crate eventual;
 extern crate itertools;
-extern crate linked_hash_map;
 extern crate num;
 extern crate unicode;
 


### PR DESCRIPTION
Objects are reimplemented using vectors.
