### PR TITLE
Move to Rust beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: rust
-rust: nightly
+rust: beta
 notifications:
   irc: "chat.freenode.net#jqsh"


### PR DESCRIPTION
The build on beta has been fixed in #8, this just tells Travis CI to switch to the beta toolchain.
