### PR TITLE
Implement filter grouping

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -7,10 +7,11 @@ use eventual::Async;
 
 use unicode::UString;
 
-use jqsh::lang::{Context, Filter, channel, parser};
+use jqsh::builtin;
+use jqsh::lang::{Filter, channel, parser};
 
 fn main() {
-    let mut repl_context = Context::interactive();
+    let mut repl_context = builtin::context();
     while let Some(source_utf8) = readline::readline("jqsh> ") {
         readline::add_history(&source_utf8);
         let source = UString::from(source_utf8);

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -1,0 +1,18 @@
+use std::sync::Arc;
+
+use num::{FromPrimitive, BigRational};
+
+use lang::context::{Context, PrecedenceGroup};
+
+/// The default context for interactive shell sessions.
+pub fn context() -> Context {
+    Context {
+        filter_allowed: Arc::new(Box::new(|_| true)),
+        operators: vec![
+            (1_000_000, PrecedenceGroup::Circumfix),
+            (-1_000_000, PrecedenceGroup::AndThen)
+        ].into_iter().map(|(precedence, group)| {
+            (BigRational::from_integer(FromPrimitive::from_i32(precedence).unwrap()), group)
+        }).collect()
+    }
+}

--- a/src/lang/context.rs
+++ b/src/lang/context.rs
@@ -2,13 +2,14 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Arc;
 
-use num::{FromPrimitive, BigRational};
+use num::BigRational;
 
 use lang::Filter;
 
 #[derive(Clone, Debug)]
 pub enum PrecedenceGroup {
-    AndThen
+    AndThen,
+    Circumfix
 }
 
 #[derive(Clone)]
@@ -17,20 +18,6 @@ pub struct Context {
     pub filter_allowed: Arc<Box<Fn(&Filter) -> bool + Send + Sync>>,
     /// The context's operators, in decreasing precedence.
     pub operators: BTreeMap<BigRational, PrecedenceGroup>
-}
-
-impl Context {
-    /// The default context for interactive shell sessions.
-    pub fn interactive() -> Context {
-        Context {
-            filter_allowed: Arc::new(Box::new(|_| true)),
-            operators: vec![
-                (-1000000, PrecedenceGroup::AndThen)
-            ].into_iter().map(|(precedence, group)| {
-                (BigRational::from_integer(FromPrimitive::from_i32(precedence).unwrap()), group)
-            }).collect()
-        }
-    }
 }
 
 impl fmt::Debug for Context {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ extern crate num;
 extern crate unicode;
 
 pub mod lang;
+mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,6 @@ extern crate itertools;
 extern crate num;
 extern crate unicode;
 
+pub mod builtin;
 pub mod lang;
 mod util;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,53 @@
+use lang::channel::{Sender, Receiver};
+use lang::filter::Filter;
+
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct Labeled<T> {
+    label: String,
+    value: T
+}
+
+impl<T> Labeled<T> {
+    pub fn new(value: T) -> Labeled<T> {
+        Labeled::new_with_label("", value)
+    }
+
+    pub fn new_with_label<S: Into<String>>(label: S, value: T) -> Labeled<T> {
+        Labeled {
+            label: label.into(),
+            value: value
+        }
+    }
+}
+
+impl<T> From<T> for Labeled<T> {
+    fn from(value: T) -> Labeled<T> {
+        Labeled::new(value)
+    }
+}
+
+impl<T> Deref for Labeled<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.value
+    }
+}
+
+impl<T> DerefMut for Labeled<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+}
+
+impl<T> fmt::Debug for Labeled<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.label, f)
+    }
+}
+
+pub type FilterFn = Labeled<Arc<Fn(&[Filter], Receiver, Sender) + Send + Sync>>;

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,11 +12,7 @@ pub struct Labeled<T> {
 }
 
 impl<T> Labeled<T> {
-    pub fn new(value: T) -> Labeled<T> {
-        Labeled::new_with_label("", value)
-    }
-
-    pub fn new_with_label<S: Into<String>>(label: S, value: T) -> Labeled<T> {
+    pub fn new<S: Into<String>>(label: S, value: T) -> Labeled<T> {
         Labeled {
             label: label.into(),
             value: value
@@ -26,7 +22,7 @@ impl<T> Labeled<T> {
 
 impl<T> From<T> for Labeled<T> {
     fn from(value: T) -> Labeled<T> {
-        Labeled::new(value)
+        Labeled::new("", value)
     }
 }
 


### PR DESCRIPTION
This adds the “filter group” filter (written `(α)`) to the built-in context. It also includes some work towards creating filters using function arguments instead of defining them directly within the `Filter` implementation.
