### PR TITLE
Implement comments

### DIFF
--- a/src/lang/parser.rs
+++ b/src/lang/parser.rs
@@ -152,6 +152,9 @@ impl Iterator for Tokens {
         use self::Token::*;
 
         match self.code.next() {
+            Some('\t') |
+            Some('\n') |
+            Some('\r') |
             Some(' ') => Some(Whitespace),
             Some('(') => Some(OpenParen),
             Some(')') => Some(CloseParen),

--- a/src/lang/parser.rs
+++ b/src/lang/parser.rs
@@ -156,6 +156,12 @@ impl Iterator for Tokens {
             Some('\n') |
             Some('\r') |
             Some(' ') => Some(Whitespace),
+            Some('#') => {
+                while self.code.peek().map(|c| c != '\n').unwrap_or(false) {
+                    self.code.next(); // discard comment contents
+                }
+                Some(Whitespace) // comments are treated as whitespace
+            }
             Some('(') => Some(OpenParen),
             Some(')') => Some(CloseParen),
             Some(';') => {


### PR DESCRIPTION
This pull request implements comments (tokenized as whitespace), and also allows tabs, newlines, and carriage returns to be used as whitespace.
